### PR TITLE
save signature png data in base64 format

### DIFF
--- a/lib/ui/reactive/reactive_signature_string.dart
+++ b/lib/ui/reactive/reactive_signature_string.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -189,11 +190,13 @@ class _ReactiveTextFieldState
 class StringUnit8ListAccessor extends ControlValueAccessor<String, Uint8List> {
   @override
   Uint8List? modelToViewValue(String? modelValue) {
-    return modelValue == null ? null : Uint8List.fromList(modelValue.codeUnits);
+    return modelValue == null
+        ? null
+        : const Base64Decoder().convert(modelValue);
   }
 
   @override
   String? viewToModelValue(Uint8List? viewValue) {
-    return viewValue == null ? null : String.fromCharCodes(viewValue);
+    return viewValue == null ? null : const Base64Encoder().convert(viewValue);
   }
 }


### PR DESCRIPTION
Survey.js signature data are usually represented in the model as base64 strings. Please consider adopt this convention.