### PR TITLE
Added SurveyStylesConfiguration class for hiding survey title

### DIFF
--- a/lib/ui/survey_styles_configuration.dart
+++ b/lib/ui/survey_styles_configuration.dart
@@ -1,0 +1,7 @@
+class SurveyStylesConfiguration {
+  const SurveyStylesConfiguration({
+    this.showSurveyTitle = true,
+  });
+
+  final bool showSurveyTitle;
+}

--- a/lib/ui/survey_widget.dart
+++ b/lib/ui/survey_widget.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_survey_js/generated/l10n.dart';
 import 'package:flutter_survey_js/model/survey.dart' as s;
+import 'package:flutter_survey_js/ui/survey_styles_configuration.dart';
 import 'package:im_stepper/stepper.dart';
 import 'package:logging/logging.dart';
 import 'package:reactive_forms/reactive_forms.dart';
@@ -20,6 +21,7 @@ class SurveyWidget extends StatefulWidget {
   final bool showQuestionsInOnePage;
   final SurveyController? controller;
   final bool hideSubmitButton;
+  final SurveyStylesConfiguration surveyStylesConfiguration;
 
   const SurveyWidget({
     Key? key,
@@ -30,6 +32,7 @@ class SurveyWidget extends StatefulWidget {
     this.showQuestionsInOnePage = false,
     this.controller,
     this.hideSubmitButton = false,
+    this.surveyStylesConfiguration = const SurveyStylesConfiguration(),
   }) : super(key: key);
   @override
   State<StatefulWidget> createState() => SurveyWidgetState();
@@ -70,7 +73,8 @@ class SurveyWidgetState extends State<SurveyWidget> {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        if (widget.survey.title != null)
+        if (widget.survey.title != null &&
+            widget.surveyStylesConfiguration.showSurveyTitle)
           Container(
             child: ListTile(
               title: Text(widget.survey.title!),
@@ -160,6 +164,7 @@ class SurveyWidgetState extends State<SurveyWidget> {
     }
     final elementsState = ElementsState(status);
     return SurveyProvider(
+        surveyStylesConfiguration: widget.surveyStylesConfiguration,
         survey: widget.survey,
         formGroup: formGroup,
         elementsState: elementsState,
@@ -277,11 +282,13 @@ class SurveyProvider extends InheritedWidget {
   final s.Survey survey;
   final FormGroup formGroup;
   final ElementsState elementsState;
+  final SurveyStylesConfiguration surveyStylesConfiguration;
   SurveyProvider({
     required this.elementsState,
     required this.child,
     required this.survey,
     required this.formGroup,
+    required this.surveyStylesConfiguration,
   }) : super(child: child);
 
   static SurveyProvider of(BuildContext context) {

--- a/test/ui/survey_widget_test.dart
+++ b/test/ui/survey_widget_test.dart
@@ -3,11 +3,84 @@ import 'dart:core';
 import 'package:flutter/material.dart';
 import 'package:flutter_survey_js/survey.dart';
 import 'package:flutter_survey_js/survey.dart' as s;
+import 'package:flutter_survey_js/ui/survey_styles_configuration.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../test_data.dart';
 
 main() {
+  group('title', () {
+    testWidgets(
+        'is shown if SurveyStylesConfiguration has shouldShowTitle as true',
+        (widgetTester) async {
+      var title = 'My Title';
+
+      await widgetTester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: [
+            s.MultiAppLocalizationsDelegate(),
+          ],
+          home: Material(
+            child: SurveyWidget(
+              surveyStylesConfiguration: SurveyStylesConfiguration(
+                showSurveyTitle: true,
+              ),
+              survey: TestData.survey(
+                title: title,
+                pages: [
+                  TestData.page(
+                    elements: [
+                      s.Text(),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await widgetTester.pump();
+      await widgetTester.idle();
+
+      expect(find.text(title), findsOneWidget);
+    });
+
+    testWidgets(
+        'is not shown if SurveyStylesConfiguration has shouldShowTitle as false',
+        (widgetTester) async {
+      var title = 'My Title';
+
+      await widgetTester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: [
+            s.MultiAppLocalizationsDelegate(),
+          ],
+          home: Material(
+            child: SurveyWidget(
+              surveyStylesConfiguration: SurveyStylesConfiguration(
+                showSurveyTitle: false,
+              ),
+              survey: TestData.survey(
+                title: title,
+                pages: [
+                  TestData.page(
+                    elements: [
+                      s.Text(),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await widgetTester.pump();
+      await widgetTester.idle();
+
+      expect(find.text(title), findsNothing);
+    });
+  });
+
   group('SurveyController', () {
     group('submit', () {
       testWidgets('calls SurveyWidget.onSubmit', (widgetTester) async {


### PR DESCRIPTION
### Description
- This resolves issue #16 
- Additional configurations can be added to the `SurveyStyleConfiguration` class for further survey configurations, such as:
    - Padding
    - Text Styles
    - Optional Scroll Controller
    - etc.