### PR TITLE
Switch Safe Area and Scaffold in Pages so that there is no white area above the app bar on devices with SafeAreas

### DIFF
--- a/example/lib/answer.dart
+++ b/example/lib/answer.dart
@@ -20,60 +20,62 @@ class AnswerPageState extends State<AnswerPage> {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-        child: Scaffold(
-            appBar: AppBar(
-              title: Text('Input your answer'),
-            ),
-            body: Column(children: [
-              Text("Choose layout to continue"),
-              Wrap(
-                direction: Axis.horizontal,
-                children: [
-                  ElevatedButton(
-                    onPressed: () => {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => Simple(
-                                  survey: widget.survey,
-                                  answer: toAnswer(answer.toString()),
-                                )),
-                      )
-                    },
-                    child: Text(
-                      'Simple',
-                    ),
-                  ),
-                  ElevatedButton(
-                    onPressed: () => {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => CustomLayoutPage(
-                                  survey: widget.survey,
-                                  answer: toAnswer(answer.toString()),
-                                )),
-                      )
-                    },
-                    child: Text(
-                      'Customize',
-                    ),
-                  ),
-                ],
-              ),
-              Expanded(
-                  child: JsonEditor.element(
-                element: answer,
-                onValueChanged: (value) {
-                  if (value.toString() != answer.toString() && mounted) {
-                    setState(() {
-                      answer = value;
-                    });
-                  }
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Input your answer'),
+      ),
+      body: SafeArea(
+        child: Column(children: [
+          Text("Choose layout to continue"),
+          Wrap(
+            direction: Axis.horizontal,
+            children: [
+              ElevatedButton(
+                onPressed: () => {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => Simple(
+                              survey: widget.survey,
+                              answer: toAnswer(answer.toString()),
+                            )),
+                  )
                 },
-              ))
-            ])));
+                child: Text(
+                  'Simple',
+                ),
+              ),
+              ElevatedButton(
+                onPressed: () => {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => CustomLayoutPage(
+                              survey: widget.survey,
+                              answer: toAnswer(answer.toString()),
+                            )),
+                  )
+                },
+                child: Text(
+                  'Customize',
+                ),
+              ),
+            ],
+          ),
+          Expanded(
+              child: JsonEditor.element(
+            element: answer,
+            onValueChanged: (value) {
+              if (value.toString() != answer.toString() && mounted) {
+                setState(() {
+                  answer = value;
+                });
+              }
+            },
+          ))
+        ]),
+      ),
+    );
   }
 }
 

--- a/example/lib/components/custom_layout.dart
+++ b/example/lib/components/custom_layout.dart
@@ -13,50 +13,52 @@ class CustomLayoutPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-        child: Scaffold(
-            appBar: AppBar(
-              title: Text('Survey Customize:' + (survey?.title ?? '')),
-            ),
-            body: survey == null
-                ? Center(
-                    child: CircularProgressIndicator(),
-                  )
-                : s.SurveyWidget(
-                    showQuestionsInOnePage: true,
-                    survey: survey!,
-                    answer: answer,
-                    onChange: (v) {
-                      print(v);
-                    },
-                    builder: (context) => CustomLayout(),
-                    onSubmit: (v) {
-                      print(v);
-                      showModalBottomSheet<void>(
-                        context: context,
-                        builder: (BuildContext context) {
-                          return Container(
-                            height: 400,
-                            child: Center(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.stretch,
-                                children: [
-                                  Expanded(
-                                      child: Container(
-                                          child: SingleChildScrollView(
-                                              child: Text(v.toString())))),
-                                  ElevatedButton(
-                                    child: const Text('Close'),
-                                    onPressed: () => Navigator.pop(context),
-                                  )
-                                ],
-                              ),
-                            ),
-                          );
-                        },
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Survey Customize:' + (survey?.title ?? '')),
+      ),
+      body: SafeArea(
+        child: survey == null
+            ? Center(
+                child: CircularProgressIndicator(),
+              )
+            : s.SurveyWidget(
+                showQuestionsInOnePage: true,
+                survey: survey!,
+                answer: answer,
+                onChange: (v) {
+                  print(v);
+                },
+                builder: (context) => CustomLayout(),
+                onSubmit: (v) {
+                  print(v);
+                  showModalBottomSheet<void>(
+                    context: context,
+                    builder: (BuildContext context) {
+                      return Container(
+                        height: 400,
+                        child: Center(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              Expanded(
+                                  child: Container(
+                                      child: SingleChildScrollView(
+                                          child: Text(v.toString())))),
+                              ElevatedButton(
+                                child: const Text('Close'),
+                                onPressed: () => Navigator.pop(context),
+                              )
+                            ],
+                          ),
+                        ),
                       );
                     },
-                  )));
+                  );
+                },
+              ),
+      ),
+    );
   }
 }
 

--- a/example/lib/components/simple.dart
+++ b/example/lib/components/simple.dart
@@ -8,12 +8,12 @@ class Simple extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-        child: Scaffold(
-            appBar: AppBar(
-              title: Text('Survey test'),
-            ),
-            body: survey == null
+    return Scaffold(
+        appBar: AppBar(
+          title: Text('Survey test'),
+        ),
+        body: SafeArea(
+            child: survey == null
                 ? Center(
                     child: CircularProgressIndicator(),
                   )


### PR DESCRIPTION
Switch Safe Area and Scaffold in Pages so that there is no white area above the app bar on devices with SafeAreas.

This is a minor improvement that is relatively safe and makes the example look nicer.
<span>
<img src="https://user-images.githubusercontent.com/166325/231288511-caa93226-de6c-46e6-ae3b-034977d81e39.png" width="200"> <img src="https://user-images.githubusercontent.com/166325/231288517-197b8fb6-081e-4dc6-978a-1c3f5debb487.png" width="200">
</span>