### PR TITLE
Fixed Issue #54: `SurveyWidget.formGroup` is being reset whenever `didUpdateWidget` is called

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   fake_async:
     dependency: transitive
     description:

--- a/lib/model/element.dart
+++ b/lib/model/element.dart
@@ -1,6 +1,6 @@
 part of 'survey.dart';
 
-abstract class ElementBase {
+abstract class ElementBase extends Equatable {
   String? get type;
 
   String? get name;
@@ -69,6 +69,12 @@ abstract class ElementBase {
         return UnsupportedElement.fromJson(d);
     }
   }
+
+  @override
+  List<Object?> get props => [
+        type,
+        name,
+      ];
 }
 
 class UnsupportedElement extends ElementBase {
@@ -99,4 +105,10 @@ class UnsupportedElement extends ElementBase {
         name: json['name'],
         title: json['title'],
       );
+
+  @override
+  List<Object?> get props => [
+        ...super.props,
+        title,
+      ];
 }

--- a/lib/model/expression_item.dart
+++ b/lib/model/expression_item.dart
@@ -1,8 +1,11 @@
 part of 'survey.dart';
 
 @JsonSerializable(includeIfNull: false)
-class ExpressionItem {
+class ExpressionItem extends Equatable {
   String? expression;
+
+  @override
+  List<Object?> get props => [expression];
 }
 
 @JsonSerializable(includeIfNull: false)
@@ -12,6 +15,12 @@ class UrlConditionItem extends ExpressionItem {
   factory UrlConditionItem.fromJson(Map<String, dynamic> json) =>
       _$UrlConditionItemFromJson(json);
   Map<String, dynamic> toJson() => _$UrlConditionItemToJson(this);
+
+  @override
+  List<Object?> get props => [
+        ...super.props,
+        url,
+      ];
 }
 
 @JsonSerializable(includeIfNull: false)
@@ -21,4 +30,7 @@ class HtmlConditionItem extends ExpressionItem {
   factory HtmlConditionItem.fromJson(Map<String, dynamic> json) =>
       _$HtmlConditionItemFromJson(json);
   Map<String, dynamic> toJson() => _$HtmlConditionItemToJson(this);
+
+  @override
+  List<Object?> get props => [...super.props, html];
 }

--- a/lib/model/page.dart
+++ b/lib/model/page.dart
@@ -26,6 +26,15 @@ class Page extends PanelBase {
             .toList();
   @override
   Map<String, dynamic> toJson() => _$PageToJson(this);
+
+  @override
+  List<Object?> get props => [
+        navigationButtonsVisibility,
+        questionsOrder,
+        maxTimeToFinish,
+        navigationTitle,
+        navigationDescription,
+      ];
 }
 
 abstract class PanelBase extends ElementBase {
@@ -42,4 +51,19 @@ abstract class PanelBase extends ElementBase {
   //
   String? title;
   String? description;
+
+  @override
+  List<Object?> get props => [
+        ...super.props,
+        name,
+        elements,
+        visible,
+        visibleIf,
+        enableIf,
+        requiredIf,
+        readOnly,
+        questionTitleLocation,
+        title,
+        description,
+      ];
 }

--- a/lib/model/survey.dart
+++ b/lib/model/survey.dart
@@ -1,3 +1,4 @@
+import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'element.dart';
@@ -13,7 +14,7 @@ part 'trigger.dart';
 part 'validator.dart';
 
 @JsonSerializable(includeIfNull: false)
-class Survey {
+class Survey extends Equatable {
   String? locale;
   String? title;
   String? description;
@@ -129,6 +130,72 @@ class Survey {
     }
     return inputValue;
   }
+
+  @override
+  List<Object?> get props => [
+        locale,
+        title,
+        description,
+        logo,
+        logoWidth,
+        logoFit,
+        logoPosition,
+        focusFirstQuestionAutomatic,
+        focusOnFirstError,
+        completedHtml,
+        completedBeforeHtml,
+        completedHtmlOnCondition,
+        loadingHtml,
+        pages,
+        triggers,
+        calculatedValues,
+        surveyId,
+        surveyPostId,
+        surveyShowDataSaving,
+        cookieName,
+        sendResultOnPageNext,
+        showNavigationButtons,
+        showPrevButton,
+        showTitle,
+        showPageTitles,
+        showCompletedPage,
+        navigateToUrl,
+        navigateToUrlOnCondition,
+        questionsOrder,
+        showPageNumbers,
+        showQuestionNumbers,
+        questionTitleLocation,
+        questionDescriptionLocation,
+        questionErrorLocation,
+        showProgressBar,
+        progressBarType,
+        mode,
+        storeOthersAsComment,
+        maxTextLength,
+        maxOthersLength,
+        goNextPageAutomatic,
+        clearInvisibleValues,
+        checkErrorsMode,
+        textUpdateMode,
+        startSurveyText,
+        pagePrevText,
+        pageNextText,
+        completeText,
+        previewText,
+        editText,
+        requiredText,
+        questionStartIndex,
+        questionTitlePattern,
+        questionTitleTemplate,
+        firstPageIsStarted,
+        isSinglePage,
+        questionsOnPageMode,
+        showPreviewBeforeComplete,
+        maxTimeToFinish,
+        maxTimeToFinishPage,
+        showTimerPanel,
+        showTimerPanelMode,
+      ];
 }
 
 @JsonSerializable(includeIfNull: false)
@@ -531,7 +598,7 @@ class SignaturePad extends Question {
 }
 
 @JsonSerializable(includeIfNull: false)
-class CalculatedValue {
+class CalculatedValue extends Equatable {
   String? name;
   String? expression;
   bool? includeIntoResult;
@@ -539,6 +606,13 @@ class CalculatedValue {
   factory CalculatedValue.fromJson(Map<String, dynamic> json) =>
       _$CalculatedValueFromJson(json);
   Map<String, dynamic> toJson() => _$CalculatedValueToJson(this);
+
+  @override
+  List<Object?> get props => [
+        name,
+        expression,
+        includeIntoResult,
+      ];
 }
 
 @JsonSerializable(includeIfNull: false)

--- a/lib/model/trigger.dart
+++ b/lib/model/trigger.dart
@@ -9,11 +9,18 @@ final surveyTriggerMap =
   RunExpressionTrigger.$type: (d) => RunExpressionTrigger.fromJson(d),
 };
 
-abstract class Trigger {
+abstract class Trigger extends Equatable {
   String? operator;
   String? value;
   String? expression;
   Trigger();
+
+  @override
+  List<Object?> get props => [
+        operator,
+        value,
+        expression,
+      ];
 }
 
 abstract class SurveyTrigger extends Trigger {
@@ -29,6 +36,12 @@ abstract class SurveyTrigger extends Trigger {
     throw UnsupportedError('SurveyTrigger');
   }
   Map<String, dynamic> toJson();
+
+  @override
+  List<Object?> get props => [
+        ...super.props,
+        name,
+      ];
 }
 
 @JsonSerializable(includeIfNull: false)
@@ -44,6 +57,13 @@ class VisibleTrigger extends SurveyTrigger {
       _$VisibleTriggerFromJson(json);
   @override
   Map<String, dynamic> toJson() => _$VisibleTriggerToJson(this);
+
+  @override
+  List<Object?> get props => [
+        ...super.props,
+        pages,
+        questions,
+      ];
 }
 
 @JsonSerializable(includeIfNull: false)
@@ -72,6 +92,14 @@ class SetvalueTrigger extends SurveyTrigger {
       _$SetvalueTriggerFromJson(json);
   @override
   Map<String, dynamic> toJson() => _$SetvalueTriggerToJson(this);
+
+  @override
+  List<Object?> get props => [
+        ...super.props,
+        setToName,
+        setValue,
+        isVariable,
+      ];
 }
 
 @JsonSerializable(includeIfNull: false)
@@ -86,6 +114,13 @@ class CopyValueTrigger extends SurveyTrigger {
       _$CopyValueTriggerFromJson(json);
   @override
   Map<String, dynamic> toJson() => _$CopyValueTriggerToJson(this);
+
+  @override
+  List<Object?> get props => [
+        ...super.props,
+        setToName,
+        fromName,
+      ];
 }
 
 @JsonSerializable(includeIfNull: false)
@@ -99,6 +134,12 @@ class SkipTrigger extends SurveyTrigger {
       _$SkipTriggerFromJson(json);
   @override
   Map<String, dynamic> toJson() => _$SkipTriggerToJson(this);
+
+  @override
+  List<Object?> get props => [
+        ...super.props,
+        gotoName,
+      ];
 }
 
 @JsonSerializable(includeIfNull: false)
@@ -114,4 +155,11 @@ class RunExpressionTrigger extends SurveyTrigger {
       _$RunExpressionTriggerFromJson(json);
   @override
   Map<String, dynamic> toJson() => _$RunExpressionTriggerToJson(this);
+
+  @override
+  List<Object?> get props => [
+        ...super.props,
+        setToName,
+        runExpression,
+      ];
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -193,6 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   platform: ^3.1.0
   file: ^6.1.4
   group_button: ^5.2.2
+  equatable: ^2.0.5
 
 
 dev_dependencies:


### PR DESCRIPTION
This would close Issue #54

See the thread [here](https://github.com/goxiaoy/flutter_survey_js/pull/53) to understand why making `Survey` extend `Equatable` resolves this bug.