### PR TITLE
use `titleLarge` for question title

### DIFF
--- a/lib/ui/elements/question_title.dart
+++ b/lib/ui/elements/question_title.dart
@@ -23,7 +23,7 @@ class QuestionTitle extends StatelessWidget {
       }
     }
 
-    titleTextStyle() => Theme.of(context).textTheme.titleMedium;
+    titleTextStyle() => Theme.of(context).textTheme.titleLarge;
 
     title() {
       List<Widget> listTitle = <Widget>[];


### PR DESCRIPTION
use `titleLarge` instead to distinguish between question title and choices.