### PR TITLE
Add dependency_override for intl ^0.18.0

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -36,6 +36,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+dependency_overrides:
+  intl: ^0.18.0
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,6 @@ dependencies:
   flutter_survey_js_model: ^0.0.2-dev.4
   built_value: ">=8.4.0 <9.0.0"
   built_collection: ">=5.1.1 <6.0.0"
-  intl: ^0.18.0
 
 dev_dependencies:
   flutter_test:
@@ -41,6 +40,9 @@ dev_dependencies:
   build_runner: ^2.3.3
   flutter_lints: ^2.0.1
   melos: ^3.0.1
+
+dependency_overrides:
+  intl: ^0.18.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
On older versions of Flutter, intl 0.18.0 conflicts with flutter_localizations, preventing the project from building. Explicitly telling the project to use intl ^0.18.0 resolves this issue.