### PR TITLE
Moved const in survey_configuration.dart to fix lower flutter versions

### DIFF
--- a/lib/ui/survey_configuration.dart
+++ b/lib/ui/survey_configuration.dart
@@ -31,8 +31,8 @@ Widget defaultUnsupportedBuilder(BuildContext context, s.Elementbase element,
 Widget defaultSeparatorBuilder(
   BuildContext context,
 ) {
-  return const Wrap(
-    children: [
+  return Wrap(
+    children: const [
       SizedBox(
         height: 5,
       ),


### PR DESCRIPTION
There is a `const` located in `survey_configuration.dart` that is preventing lower Flutter versions from building. This commit would fix this build error.