### PR TITLE
Only increment the index if it is not a Nonvalue

### DIFF
--- a/lib/ui/survey_widget.dart
+++ b/lib/ui/survey_widget.dart
@@ -83,7 +83,7 @@ class SurveyWidgetState extends State<SurveyWidget> {
     for (final kv in _controlsMap.entries) {
       var visible = true;
       status[kv.key] = ElementStatus(indexAll: index);
-      if (visible) {
+      if (visible && kv.key is! Nonvalue) {
         index++;
       }
     }


### PR DESCRIPTION
### Description
- Closes #101 
- Only increment the index if the element is not of `Nonvalue` type

| Web | Mobile before PR |
| ----- | ----- |
| <img src="https://github.com/goxiaoy/flutter_survey_js/assets/5490028/bd13e77a-dc0c-47c3-9183-001d92cbea03" width="1000"/> | <img src="https://github.com/goxiaoy/flutter_survey_js/assets/5490028/e3fc636d-62b7-4592-8179-1dfc29b1500e" width="1000" /> |

| Web | Mobile after PR |
| ----- | ----- |
| <img src="https://github.com/goxiaoy/flutter_survey_js/assets/5490028/bd13e77a-dc0c-47c3-9183-001d92cbea03" width="1000"/> | <img src="https://github.com/goxiaoy/flutter_survey_js/assets/5490028/2d76b2f6-0445-4038-9709-49e0ed5443eb" width="1000" /> |

